### PR TITLE
Redraw separators on resize

### DIFF
--- a/autoload/copilot_chat/api.vim
+++ b/autoload/copilot_chat/api.vim
@@ -61,7 +61,7 @@ function! copilot_chat#api#handle_job_close(channel, msg) abort
     endif
   endfor
 
-  let l:width = winwidth(0)-2
+  let l:width = winwidth(0) - 2 - getwininfo(win_getid())[0].textoff
   let l:separator = ' '
   let l:separator .= repeat('━', l:width)
   call copilot_chat#buffer#append_message(l:separator)

--- a/autoload/copilot_chat/buffer.vim
+++ b/autoload/copilot_chat/buffer.vim
@@ -205,4 +205,31 @@ function! copilot_chat#buffer#on_delete(bufnr) abort
   let g:copilot_chat_active_buffer = -1
 endfunction
 
+function! copilot_chat#buffer#resize() abort
+  if g:copilot_chat_active_buffer == -1
+    return
+  endif
+
+  let currwin = winnr()
+  let currtab = tabpagenr()
+
+  for tabnr in range(1, tabpagenr('$'))
+    exec 'normal!' tabnr . 'gt'
+    for winnr in range(1, winnr('$'))
+      exec winnr . 'wincmd w'
+      if &filetype !=# 'copilot_chat'
+        continue
+      endif
+      let l:width = winwidth(0) - 2 - getwininfo(win_getid())[0].textoff
+      let curpos = getcurpos()
+      exec '%s/^ ━\+/ ' . repeat('━', l:width) . '/ge'
+      exec '%s/^ ━\+/ ' . repeat('━', l:width) . '/ge'
+      call setpos('.', curpos)
+    endfor
+  endfor
+
+  exec 'normal!' currtab . 'gt'
+  exec currwin . 'wincmd w'
+endfunction
+
 " vim:set ft=vim sw=2 sts=2 et:

--- a/plugin/copilot_chat.vim
+++ b/plugin/copilot_chat.vim
@@ -28,6 +28,7 @@ vnoremap <silent> <Plug>CopilotChatAddSelection :<C-u>call copilot_chat#buffer#a
 augroup CopilotChat
   autocmd!
   autocmd FileType copilot_chat autocmd BufDelete <buffer> call copilot_chat#buffer#on_delete(expand('<abuf>'))
+  autocmd VimResized,WinResized * call copilot_chat#buffer#resize()
 augroup END
 
 " vim:set ft=vim sw=2 sts=2 et:


### PR DESCRIPTION
This redraws separators when windows or Vim is resized so that continue to be as long as the full width of the window.  It looks through all tabs and windows for copilot chat buffers.

I also neglected to take `textoff` into account on a previous commit, so this PR also fixes that.