### PR TITLE
Return cursorpos in other tabs

### DIFF
--- a/autoload/copilot_chat/buffer.vim
+++ b/autoload/copilot_chat/buffer.vim
@@ -210,11 +210,12 @@ function! copilot_chat#buffer#resize() abort
     return
   endif
 
-  let currwin = winnr()
   let currtab = tabpagenr()
 
   for tabnr in range(1, tabpagenr('$'))
     exec 'normal!' tabnr . 'gt'
+    let currwin = winnr()
+
     for winnr in range(1, winnr('$'))
       exec winnr . 'wincmd w'
       if &filetype !=# 'copilot_chat'
@@ -226,10 +227,11 @@ function! copilot_chat#buffer#resize() abort
       exec '%s/^ ━\+/ ' . repeat('━', l:width) . '/ge'
       call setpos('.', curpos)
     endfor
+
+    exec currwin . 'wincmd w'
   endfor
 
   exec 'normal!' currtab . 'gt'
-  exec currwin . 'wincmd w'
 endfunction
 
 " vim:set ft=vim sw=2 sts=2 et:


### PR DESCRIPTION
Hello once again!

This is actually fixing a small bug with my last PR.  This ensure the cursor is returned to the proper window in _other_ tabs.