### PR TITLE
Check vim version for WinResized event

### DIFF
--- a/plugin/copilot_chat.vim
+++ b/plugin/copilot_chat.vim
@@ -28,7 +28,11 @@ augroup CopilotChat
   autocmd!
   autocmd FileType copilot_chat autocmd BufDelete <buffer> call copilot_chat#buffer#on_delete(expand('<abuf>'))
   autocmd FileType copilot_chat autocmd BufEnter,TextChanged,TextChangedI <buffer> call copilot_chat#buffer#apply_code_block_syntax()
-  autocmd VimResized,WinResized * call copilot_chat#buffer#resize()
+  if has('patch-9.0.0917')
+    autocmd VimResized,WinResized * call copilot_chat#buffer#resize()
+  else
+    autocmd VimResized * call copilot_chat#buffer#resize()
+  endif
 augroup END
 
 " vim:set ft=vim sw=2 sts=2 et:


### PR DESCRIPTION
Hi Dan,

This fixes #27 insofar as it won't cause an error for people on older versions of Vim.  I haven't hacked around it as I just wanted to keep it from erroring for people.