### PR TITLE
[WIP] file context

### DIFF
--- a/autoload/copilot_chat.vim
+++ b/autoload/copilot_chat.vim
@@ -1,7 +1,6 @@
 scriptencoding utf-8
 
 function! copilot_chat#open_chat() abort
-
   call copilot_chat#auth#verify_signin()
 
   if copilot_chat#buffer#has_active_chat() &&

--- a/autoload/copilot_chat.vim
+++ b/autoload/copilot_chat.vim
@@ -49,6 +49,7 @@ function! copilot_chat#submit_message() abort
   let l:end_line = line('$')
 
   let l:lines = getline(l:start_line, l:end_line)
+  let l:file_list = []
 
   for l:i in range(len(l:lines))
     let l:line = l:lines[l:i]
@@ -58,11 +59,14 @@ function! copilot_chat#submit_message() abort
       if has_key(g:copilot_chat_prompts, l:text)
         let l:lines[l:i] = g:copilot_chat_prompts[l:text]
       endif
+    elseif l:line =~? '^#file:'
+      let l:filename = matchstr(l:line, '^#file:\s*\zs.*\ze$')
+      call add(l:file_list, l:filename)
     endif
   endfor
   let l:message = join(l:lines, "\n")
 
-  call copilot_chat#api#async_request(l:message)
+  call copilot_chat#api#async_request(l:message, l:file_list)
 endfunction
 
 function! copilot_chat#http(method, url, headers, body) abort

--- a/autoload/copilot_chat/api.vim
+++ b/autoload/copilot_chat/api.vim
@@ -2,7 +2,7 @@ scriptencoding utf-8
 
 let s:curl_output = []
 
-function! copilot_chat#api#async_request(message) abort
+function! copilot_chat#api#async_request(message, file_list) abort
   let l:chat_token = copilot_chat#auth#verify_signin()
   let s:curl_output = []
   let l:url = 'https://api.githubcopilot.com/chat/completions'
@@ -10,7 +10,16 @@ function! copilot_chat#api#async_request(message) abort
   " for knowledge bases its just an attachment as the content
   "{'content': '<attachment id="kb:Name">\n#kb:\n</attachment>', 'role': 'user'}
   " for files similar
-  let l:messages = [{'content': a:message, 'role': 'user'}]
+  let l:messages = []
+  for file in a:file_list
+    let l:file_content = readfile(file)
+    let full_path = fnamemodify(file, ':p')
+    " TODO: get the filetype instead of just markdown
+    let l:c = '<attachment id="' . file . '">\n````markdown\n<!-- filepath: ' . full_path . ' -->\n' . join(l:file_content, "\n") . '\n```</attachment>'
+    call add(l:messages, {'content': l:c, 'role': 'user'})
+  endfor
+  call add(l:messages, {'content': a:message, 'role': 'user'})
+
   let l:data = json_encode({
         \ 'intent': v:false,
         \ 'model': g:copilot_chat_default_model,

--- a/autoload/copilot_chat/api.vim
+++ b/autoload/copilot_chat/api.vim
@@ -2,7 +2,7 @@ scriptencoding utf-8
 
 let s:curl_output = []
 
-function! copilot_chat#api#async_request(message, file_list) abort
+function! copilot_chat#api#async_request(message, file_list=[]) abort
   let l:chat_token = copilot_chat#auth#verify_signin()
   let s:curl_output = []
   let l:url = 'https://api.githubcopilot.com/chat/completions'
@@ -42,6 +42,7 @@ function! copilot_chat#api#async_request(message, file_list) abort
         \ '-d',
         \ l:data,
         \ l:url]
+  call copilot_chat#log#write(l:data)
 
   if has('nvim')
     let job = jobstart(l:curl_cmd, {

--- a/autoload/copilot_chat/log.vim
+++ b/autoload/copilot_chat/log.vim
@@ -1,0 +1,137 @@
+" Global variable to store the log buffer number
+let g:copilot_chat_log_bufnr = -1
+function! IsJSON(str)
+  try
+    call json_decode(a:str)
+    return 1
+  catch
+    return 0
+  endtry
+endfunction
+
+" Complete pretty printing solution using Vim's built-in functions
+function! PrettyPrintJSON(json_string)
+  try
+    let json_obj = json_decode(a:json_string)
+    return s:JSONStringify(json_obj, 0)
+  catch
+    return a:json_string
+  endtry
+endfunction
+
+function! s:JSONStringify(obj, indent)
+  let ind = repeat('  ', a:indent)
+
+  if type(a:obj) == v:t_dict
+    if empty(a:obj)
+      return '{}'
+    endif
+
+    let lines = ['{']
+    let items = []
+
+    for [key, val] in items(a:obj)
+      let formatted_val = s:JSONStringify(val, a:indent + 1)
+      call add(items, repeat('  ', a:indent + 1) . '"' . escape(key, '"\') . '": ' . formatted_val)
+    endfor
+
+    call extend(lines, items)
+    call add(lines, ind . '}')
+
+    return join(lines, "\n")
+
+  elseif type(a:obj) == v:t_list
+    if empty(a:obj)
+      return '[]'
+    endif
+
+    let lines = ['[']
+    let items = []
+
+    for item in a:obj
+      call add(items, repeat('  ', a:indent + 1) . s:JSONStringify(item, a:indent + 1))
+    endfor
+
+    call extend(lines, items)
+    call add(lines, ind . ']')
+
+    return join(lines, "\n")
+
+  elseif type(a:obj) == v:t_string
+    return '"' . escape(a:obj, '"\') . '"'
+
+  elseif type(a:obj) == v:t_number || type(a:obj) == v:t_float
+    return string(a:obj)
+
+  elseif type(a:obj) == v:t_bool
+    return a:obj ? 'true' : 'false'
+
+  elseif a:obj is v:null
+    return 'null'
+
+  else
+    return string(a:obj)
+  endif
+endfunction
+
+" Function to write log messages to the custom buffer
+function! copilot_chat#log#write(message)
+  if g:copilot_chat_log_bufnr == -1 || !bufexists(g:copilot_chat_log_bufnr)
+    let current_win = win_getid()
+    execute 'botright new copilot-chat-log'
+    let g:copilot_chat_log_bufnr = bufnr('%')
+
+    setlocal buftype=nofile
+    setlocal bufhidden=hide
+    setlocal noswapfile
+    setlocal nowrap
+    "setlocal nomodifiable
+    setlocal filetype=log
+    setlocal nonumber
+    setlocal norelativenumber
+
+    setlocal modifiable
+    call setline(1, '=== Copilot Chat Log ===')
+    call setline(2, '')
+    "setlocal nomodifiable
+
+    call win_gotoid(current_win)
+  endif
+
+  " Format the message
+  let timestamp = strftime('[%Y-%m-%d %H:%M:%S] ')
+
+  " Check if the message is JSON and pretty print it
+  if IsJSON(a:message)
+    let pretty_json = PrettyPrintJSON(a:message)
+    let lines = split(pretty_json, "\n")
+
+    " Add timestamp to first line
+    let lines[0] = timestamp . lines[0]
+
+    " Indent subsequent lines
+    for i in range(1, len(lines) - 1)
+      let lines[i] = repeat(' ', len(timestamp)) . lines[i]
+    endfor
+
+    " Append all lines
+    for line in lines
+      call appendbufline(g:copilot_chat_log_bufnr, '$', line)
+    endfor
+  else
+    " Regular message
+    call appendbufline(g:copilot_chat_log_bufnr, '$', timestamp . a:message)
+  endif
+endfunction
+
+" Helper function to view the log buffer
+function! CopilotViewLog()
+  if g:copilot_chat_log_bufnr != -1 && bufexists(g:copilot_chat_log_bufnr)
+    execute 'buffer ' . g:copilot_chat_log_bufnr
+  else
+    echo "No log buffer exists yet"
+  endif
+endfunction
+
+" Command to easily view logs
+"command! CopilotLog call copilot_chat#log#write()

--- a/plugin/copilot_chat.vim
+++ b/plugin/copilot_chat.vim
@@ -28,6 +28,7 @@ augroup CopilotChat
   autocmd!
   autocmd FileType copilot_chat autocmd BufDelete <buffer> call copilot_chat#buffer#on_delete(expand('<abuf>'))
   autocmd FileType copilot_chat autocmd BufEnter,TextChanged,TextChangedI <buffer> call copilot_chat#buffer#apply_code_block_syntax()
+  autocmd FileType copilot_chat autocmd TextChangedI <buffer> call copilot_chat#buffer#check_for_macro()
   if has('patch-9.0.0917')
     autocmd VimResized,WinResized * call copilot_chat#buffer#resize()
   else

--- a/syntax/copilot_chat.vim
+++ b/syntax/copilot_chat.vim
@@ -6,6 +6,7 @@ syntax match CopilotSeparatorIcon /^/
 syntax match CopilotSeparatorLine / ━\+$/
 syntax match CopilotWaiting /Waiting for response\.*$/
 syntax match CopilotPrompt /^> .*/
+syntax match CopilotFiles /^#file:.*/
 
 syntax match CopilotCodeFence /^```\(\s*\w\+\)\?$/ contains=CopilotCodeLang
 syntax match CopilotCodeLang /\w\+/ contained
@@ -19,6 +20,7 @@ highlight CopilotPrompt ctermfg=230 guifg=#FFFF33
 highlight CopilotCodeFence ctermfg=240 guifg=#585858
 highlight CopilotCodeFenceEnd ctermfg=240 guifg=#585858
 highlight CopilotCodeLang ctermfg=111 guifg=#87afff
+highlight CopilotFiles ctermfg=12 guifg=#1E90FF
 
 if !exists('g:syntax_on')
   syntax enable


### PR DESCRIPTION
> [!CAUTION]
> HERE BE DRAGONS; code is experimental and still WIP ⚠️🚧

Updates to allow sending file context in easy way. Goal is to steal all the good things other editors are doing to handle adding context.

- [x] `/tab all` macro (stolen from zed?)
- [x] `#file:` menu with basic autocomplete (respects .gitignore)
- [ ] `#files:` menu to handle directory inclusion
- [x] debugging mode: display all request details in a separate buffer (guess im lumping in agenting PoC into this)