### PR TITLE
Set nobreakindent

### DIFF
--- a/ftplugin/copilot_chat.vim
+++ b/ftplugin/copilot_chat.vim
@@ -1,4 +1,4 @@
-setlocal wrap nonumber norelativenumber
+setlocal wrap nonumber norelativenumber nobreakindent
 
 if exists('g:copilot_chat_disable_mappings') && g:copilot_chat_disable_mappings == 1
   finish


### PR DESCRIPTION
This keeps text from indenting after the first line when wrapping.

Personally I feel `textwidth` would be something that people would generally want reset in this type of buffer as well (ie, `setlocal textwidth=0`).  Not 100% sure, what do you think?  I may be wrong 😁 