### PR TITLE
Add trivial handling of missing token

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,5 +190,12 @@ function validateUser() {
 ```
 This will send the full template text + your code to Copilot.
 
+## Problems
+
+The following error message means the logged in account does not
+have CoPilot activated:
+
+> Resource not accessible by integration
+
 ## Contributing
 Please see the [contribution guide](./CONTRIBUTING.md) for more information.

--- a/autoload/copilot_chat.vim
+++ b/autoload/copilot_chat.vim
@@ -1,14 +1,14 @@
 scriptencoding utf-8
 
 function! copilot_chat#open_chat() abort
-  call copilot_chat#auth#verify_signin()
-
-  if copilot_chat#buffer#has_active_chat() &&
-     \  g:copilot_reuse_active_chat == 1
-    call copilot_chat#buffer#focus_active_chat()
-  else
-    call copilot_chat#buffer#create()
+  if copilot_chat#auth#verify_signin() != v:null
+    if copilot_chat#buffer#has_active_chat() &&
+       \  g:copilot_reuse_active_chat == 1
+      call copilot_chat#buffer#focus_active_chat()
+    else
+      call copilot_chat#buffer#create()
     normal! G
+    endif
   endif
 endfunction
 


### PR DESCRIPTION
Without this, one gets an unfriendly runtime fault saying:

> Error detected while processing function copilot#open_chat…
> E716: Key not present in Dictionary: "token"

After adding printouts to see the actual json communication, the cause becomes obvious from:

  {
    'message': 'Resource not accessible by integration',
    'can_signup_for_limited': v:true,
    'error_details': {
      'url': …
      'notification_id': 'no_copilot_access',
      'message': 'No access to GitHub Copilot found. You …
      'title': 'Sign up for GitHub Copilot'
    }
  }

Showing the message should save others from debugging this likely quite common state.