### PR TITLE
Join JSON with newline character

### DIFF
--- a/autoload/copilot_chat/config.vim
+++ b/autoload/copilot_chat/config.vim
@@ -6,7 +6,7 @@ let s:chat_config_file = g:copilot_chat_data_dir . '/config.json'
 
 " Read the config file on load
 if filereadable(s:chat_config_file)
-  let s:config_raw_data = join(readfile(s:chat_config_file), '\n')
+  let s:config_raw_data = join(readfile(s:chat_config_file), "\n")
   let s:config = json_decode(s:config_raw_data)
 else
   let s:config = {}


### PR DESCRIPTION
`join(…, '\n')` will join a string with a literal backslash followed by `n`, as `'` does not interpret backslash escapes. The intention was likely to join on `"\n"` instead, as otherwise you get a JSON decoding error on any configuration file containing a newline.