### PR TITLE
Use a temporary file for the contents of POST instead of putting everything on command line

### DIFF
--- a/autoload/copilot_chat/api.vim
+++ b/autoload/copilot_chat/api.vim
@@ -41,7 +41,6 @@ function! copilot_chat#api#async_request(messages, file_list) abort
         \ '-H', 'Authorization: Bearer ' . l:chat_token,
         \ '-H', 'Editor-Version: vscode/1.80.1',
         \ '-d',
-        \ l:data,
         \ '@' . tmpfile,
         \ l:url]
 


### PR DESCRIPTION
Fixes: #59 

When the message to be sent to copilot gets too large, it can result in error that argument list is too long.

This PR modifies the behavior of putting the full contents of the POST body onto the commandline as argument to writing it to a temporary file and then use the `@ -d tempfile` option of curl to provide the contents.

By using the `tempname` function, any temporary files will be automatically cleaned up when closing ViM