### PR TITLE
Re-add lost assistant response separator indicator

### DIFF
--- a/autoload/copilot_chat.vim
+++ b/autoload/copilot_chat.vim
@@ -53,8 +53,8 @@ function! copilot_chat#submit_message() abort
     let l:header_line = getline('.')
     let l:role = 'user'
     " Check separator icon to determine message role
-    " Separator with  icon indicates assistant response, otherwise user message
-    if stridx(l:header_line, ' ') != -1
+    " Separator with  icon indicates assistant response, otherwise user message
+    if stridx(l:header_line, ' ') != -1
       let l:role = 'assistant'
     endif
     let l:start_line = line('.') + 1


### PR DESCRIPTION
The character used to identify assistant responses seems to have gotten accidentally lost in 3469ae9, which leads to some erratic behavior in chats. Add it back.

(I did this in an environment where I am a bit blind to the upper ranges of Unicode code points, so please double check the code point, but from all I can tell with hexdumps and so on it seems correct.)