### PR TITLE
Update Editor-Version headers

### DIFF
--- a/autoload/copilot_chat/api.vim
+++ b/autoload/copilot_chat/api.vim
@@ -39,7 +39,8 @@ function! copilot_chat#api#async_request(messages, file_list) abort
         \ '-H',
         \ 'Content-Type: application/json',
         \ '-H', 'Authorization: Bearer ' . l:chat_token,
-        \ '-H', 'Editor-Version: vscode/1.80.1',
+        \ '-H', 'Editor-Version: vscode/1.107.0',
+        \ '-H', 'Editor-Plugin-Version: copilot-chat/0.36.2025121601',
         \ '-d',
         \ '@' . tmpfile,
         \ l:url]
@@ -138,9 +139,9 @@ endfunction
 
 function! copilot_chat#api#fetch_models(chat_token) abort
   let l:chat_headers = [
-    \ 'Content-Type: application/json',
     \ 'Authorization: Bearer ' . a:chat_token,
-    \ 'Editor-Version: vscode/1.80.1'
+    \ 'Editor-Version: vscode/1.107.0',
+    \ 'Editor-Plugin-Version: copilot-chat/0.36.2025121601',
     \ ]
 
   let l:response = copilot_chat#http('GET', 'https://api.githubcopilot.com/models', l:chat_headers, {})

--- a/autoload/copilot_chat/auth.vim
+++ b/autoload/copilot_chat/auth.vim
@@ -20,8 +20,9 @@ function! copilot_chat#auth#get_chat_token(fetch_new) abort
     let l:bearer_token = copilot_chat#auth#get_bearer_token()
     let l:token_url = 'https://api.github.com/copilot_internal/v2/token'
     let l:token_headers = [
+      \ 'Accept: application/json',
+      \ 'Accept-Encoding: gzip,deflate,br',
       \ 'Content-Type: application/json',
-      \ 'Editor-Version: vscode/1.80.1',
       \ 'Authorization: token ' . l:bearer_token,
       \ ]
     let l:token_data = {
@@ -63,10 +64,7 @@ function! copilot_chat#auth#get_bearer_token() abort
       \ }
       let l:token_headers = [
         \ 'Accept: application/json',
-        \ 'User-Agent: GithubCopilot/1.155.0',
         \ 'Accept-Encoding: gzip,deflate,br',
-        \ 'Editor-Plugin-Version: copilot.vim/1.16.0',
-        \ 'Editor-Version: vim/9.0.1',
         \ 'Content-Type: application/json',
         \ ]
 
@@ -83,10 +81,7 @@ function! copilot_chat#auth#get_device_token() abort
   let l:token_url = 'https://github.com/login/device/code'
   let l:headers = [
     \ 'Accept: application/json',
-    \ 'User-Agent: GithubCopilot/1.155.0',
     \ 'Accept-Encoding: gzip,deflate,br',
-    \ 'Editor-Plugin-Version: copilot.vim/1.16.0',
-    \ 'Editor-Version: Neovim/0.6.1',
     \ 'Content-Type: application/json',
     \ ]
   let l:data = {


### PR DESCRIPTION
- Updated headers: `Editor-Version` and `Editor-Plugin-Version` to latest for `api.githubcopilot.com`
- Removed unneeded headers for `github.com`

I had to update the versions, because I was asked to update VSCode and plugin when trying to get chat completions.