### PR TITLE
Add -UseBasicParsing to Invoke-WebRequest call

### DIFF
--- a/autoload/copilot_chat.vim
+++ b/autoload/copilot_chat.vim
@@ -131,7 +131,7 @@ function! copilot_chat#http(method, url, headers, body) abort
       endfor
       let l:ps_cmd .= '};'
     endif
-    let l:ps_cmd .= "Invoke-WebRequest -Uri '" . a:url . "' -Method " .a:method . " -Headers $headers -Body $body -ContentType 'application/json' | Select-Object -ExpandProperty Content"
+    let l:ps_cmd .= "Invoke-WebRequest -Uri '" . a:url . "' -Method " .a:method . " -Headers $headers -Body $body -ContentType 'application/json' -UseBasicParsing | Select-Object -ExpandProperty Content"
     let l:ps_cmd .= '"'
     let l:response = system(l:ps_cmd)
   else


### PR DESCRIPTION
Windows PowerShell 5.1 now displays a security confirmation prompt when using the `Invoke-WebRequest` command to fetch web pages without special parameters.

https://support.microsoft.com/en-us/topic/powershell-5-1-invoke-webrequest-preventing-script-execution-from-web-content-7cb95559-655e-43fd-a8bd-ceef2406b705

This requires manual confirmation on every chat message, but is easily circumvented.