### PR TITLE
[WIP] Support for Copilot Instructions

### DIFF
--- a/autoload/copilot_chat.vim
+++ b/autoload/copilot_chat.vim
@@ -84,7 +84,29 @@ export def SubmitMessage(): void
     endfor
     var message: string = join(lines, "\n")
 
-    add(messages, {'content': message, 'role': role})
+    #add(messages, {'content': message, 'role': role})
+    var prepped_message: dict<any> = { 'role': role }
+    if role == 'user'
+      prepped_message['content'] = [
+        {
+          'type': 'input_text',
+          'text': '<prompt>' .. message .. '</prompt>'
+        }
+      ]
+    else
+      prepped_message['content'] = [
+        {
+          'type': 'output_text',
+          'text': message,
+          'annotations': []
+        }
+      ]
+      prepped_message['type'] = 'message'
+      prepped_message['status'] = 'completed'
+    endif
+
+    messages->add(prepped_message)
+
     add(all_file_lists, file_list)
     cursor(line('.'), col('.') + 1)
   endwhile


### PR DESCRIPTION
Living the RE life I'm stuck trying to figure out the black magic that VSCode is using to make this happen.

I setup a simple example using "Ask" mode with a `.github/copilot-instructions.md` in the working directory
<img width="421" height="336" alt="image" src="https://github.com/user-attachments/assets/dcfb09fe-0650-47ff-8a1a-8b9be5cc6f5d" />

There are 2 requests made by VSCode for this chat message
- POST https://api.individual.githubcopilot.com/chat/completions

```
{
    "messages": [
        {
            "role": "system",
            "content": "Typical system prompt junk..|"
        },
        {
            "role": "user",
            "content": "testing"
        }
    ],
    "model": "gpt-4o-mini-2024-07-18",
    "temperature": 0.1,
    "top_p": 1,
    "max_tokens": 20,
    "stop": [
        ";"
    ],
    "n": 1,
    "stream": true
}
```

- POST https://api.individual.githubcopilot.com/responses

```
{
    "model": "gpt-5-mini",
    "input": [
        {
            "role": "system",
            "content": [
                {
                    "type": "input_text",
                    "text": "System message junk"
                }
            ]
        },
        {
            "role": "user",
            "content": [
                {
                    "type": "input_text",
                    "text": "When generating code, please follow these user provided coding instructions. You can ignore an instruction if it contradicts a system message.\n<instructions>\n<attachment filePath=\"/Users/danbradbury/Documents/Github/vinter/.github/copilot-instructions.md\">\nAlways add an emoji on the first line of your response\n</attachment>\n\n</instructions>\n<prompt>\ntesting\n</prompt>\n"
                }
            ]
        }
    ],
    "stream": true,
    "max_output_tokens": 64000,
    "store": false,
    "truncation": "disabled",
    "reasoning": {
        "summary": "detailed"
    },
    "include": [
        "reasoning.encrypted_content"
    ]
}

```

In my current working example I was able to bypass using `/chat/completions` entirely. There is obviously a change in the responses as well that would need to be parsed.. could still use the delta or the final text content that comes back from the response endpoint