### PR TITLE
Add a /buff all function

### DIFF
--- a/autoload/copilot_chat/buffer.vim
+++ b/autoload/copilot_chat/buffer.vim
@@ -379,6 +379,35 @@ export def CheckForMacro(): void
 
     # Position cursor on the empty line
     cursor(line('.'), 1)
+
+  elseif current_line =~# '/buf all'
+    # Get the position where the pattern starts
+    var pattern_start: number = match(before_cursor, '/buf all')
+
+    # Delete the pattern
+    cursor(line('.'), pattern_start + 1)
+    exec 'normal! d' .. len('/buf all') .. 'l'
+
+    # Generate list of tabs with #file: prefix, excluding current buffer
+    var buf_list: list<string> = []
+    for i in range(1, bufnr('$'))
+      var filename: string = bufname(i)
+      # Only add if it's not the current buffer and has a filename
+      if filename !=# '' && filename !~# 'CopilotChat'
+        # Use the relative path format instead of just the base filename
+        add(buf_list, $'#file: {filename}')
+      endif
+    endfor
+
+    if len(buf_list) > 0
+      var bufs_text: string = join(buf_list, "\n") .. "\n"
+      exec 'normal! i' .. bufs_text
+    else
+      exec "normal! iNo buffers found\n"
+    endif
+
+    # Position cursor on the empty line
+    cursor(line('.'), 1)
   elseif current_line =~# '#file:'
     if completion_active == 1 && !pumvisible()
       completion_active = 0

--- a/autoload/copilot_chat/buffer.vim
+++ b/autoload/copilot_chat/buffer.vim
@@ -392,8 +392,9 @@ export def CheckForMacro(): void
     var buf_list: list<string> = []
     for i in range(1, bufnr('$'))
       var filename: string = bufname(i)
-      # Only add if it's not the current buffer and has a filename
-      if filename !=# '' && filename !~# 'CopilotChat'
+      # Only add if it's not the current buffer, has a filename and is listed
+      echom buflisted(i) > 0
+      if buflisted(i) > 0 && filename !=# '' && filename !~# 'CopilotChat'
         # Use the relative path format instead of just the base filename
         add(buf_list, $'#file: {filename}')
       endif

--- a/autoload/copilot_chat/buffer.vim
+++ b/autoload/copilot_chat/buffer.vim
@@ -386,9 +386,9 @@ export def CheckForMacro(): void
 
     # Delete the pattern
     cursor(line('.'), pattern_start + 1)
-    exec 'normal! d' .. len('/buf all') .. 'l'
+    execute 'normal! d' .. len('/buf all') .. 'l'
 
-    # Generate list of tabs with #file: prefix, excluding current buffer
+    # Generate list of buffers with #file: prefix, excluding current buffer
     var buf_list: list<string> = []
     for i in range(1, bufnr('$'))
       var filename: string = bufname(i)
@@ -401,9 +401,9 @@ export def CheckForMacro(): void
 
     if len(buf_list) > 0
       var bufs_text: string = join(buf_list, "\n") .. "\n"
-      exec 'normal! i' .. bufs_text
+      execute 'normal! i' .. bufs_text
     else
-      exec "normal! iNo buffers found\n"
+      execute "normal! iNo buffers found\n"
     endif
 
     # Position cursor on the empty line


### PR DESCRIPTION
This will add a `/buff all` function to complement the `/tab all` feature for us who primarily uses buffers instead of tabs.

fixes #42