### PR TITLE
JSON response checks

### DIFF
--- a/autoload/copilot_chat/api.vim
+++ b/autoload/copilot_chat/api.vim
@@ -211,16 +211,21 @@ export def FetchModels()
 enddef
 
 def HandleFetchModelsExit(output: list<string>, status: number)
-  if status == 0
+  if status == 0 || type(output) != v:t_dict
     var response = join(output, '')
     var model_list = []
     var model_multipliers = {}
     var json_response = json_decode(response)
+	if type(json_response) != v:t_dict || !has_key(json_response, 'data') || type(json_response.data) != v:t_list
+      return
+    endif
     for item in json_response.data
-      if has_key(item, 'id')
-        model_list->add(item.id)
-        model_multipliers[item.id] = item.billing.multiplier
+      # If item isn't a dictionary with an 'id' key, skip it
+      if type(item) != v:t_dict || !has_key(item, 'id')
+        continue
       endif
+      model_list->add(item.id)
+      model_multipliers[item.id] = item.billing.multiplier
     endfor
     g:copilot_chat_available_models = model_list
     g:copilot_chat_model_multipliers = model_multipliers

--- a/autoload/copilot_chat/auth.vim
+++ b/autoload/copilot_chat/auth.vim
@@ -84,6 +84,9 @@ enddef
 def HandleGetTokenExit(lines: list<string>, status: number)
   if status == 0
     var json_response = json_decode(join(lines, ''))
+	if type(json_response) != type({})
+		return
+	endif
     var chat_token = json_response.token
     writefile([chat_token], chat_token_file)
     g:copilot_chat_token = chat_token


### PR DESCRIPTION
Some JSON parsing functionality occasionally failed over type assumption which apparently isn't always right. Add some guards to prevent vim from throwing errors here and there.

@DanBradbury - Please review this. It's been a while since I added something to this project, and a lot was changed. I'm not sure the empty `return` are correct here, but AFAIK it solves all the annoying occasional JSON errors the plugin throws. Based on `v2.1.0` rather then main, but I couldn't find a branch at that tag...